### PR TITLE
fixing modified version string

### DIFF
--- a/Tests/SortTest.php
+++ b/Tests/SortTest.php
@@ -34,7 +34,7 @@ class SortTest extends TestCase
         $v4 = '10.0.1-rc.1+build.12345';
         $v5 = '10.0.2-rc.1+build.12345'; // Biggest
         $v6 = '0.0.4';
-        $v7 = '0.0.01-alpha'; // Smallest
+        $v7 = '0.0.1-alpha'; // Smallest
 
         $sorted = Sorter::sort($v1, $v2, $v3, $v4, $v5, $v6, $v7);
 

--- a/Tests/SortTest.php
+++ b/Tests/SortTest.php
@@ -30,29 +30,30 @@ class SortTest extends TestCase
     {
         $v1 = '2.0.2';
         $v2 = '2.0.2';
-        $v3 = '0.0.1'; // Smallest
+        $v3 = '0.0.1';
         $v4 = '10.0.1-rc.1+build.12345';
         $v5 = '10.0.2-rc.1+build.12345'; // Biggest
         $v6 = '0.0.4';
+        $v7 = '0.0.01-alpha'; // Smallest
 
-        $sorted = Sorter::sort($v1, $v2, $v3, $v4, $v5, $v6);
+        $sorted = Sorter::sort($v1, $v2, $v3, $v4, $v5, $v6, $v7);
 
         $this->assertCount(
-            6,
+            7,
             $sorted
         );
 
         $this->assertEquals(
             (string) $sorted[0],
-            $v3
+            $v7
         );
         $this->assertEquals(
             (string) $sorted[1],
-            $v6
+            $v3
         );
         $this->assertEquals(
             (string) $sorted[2],
-            $v1
+            $v6
         );
         $this->assertEquals(
             (string) $sorted[3],
@@ -60,10 +61,14 @@ class SortTest extends TestCase
         );
         $this->assertEquals(
             (string) $sorted[4],
-            $v4
+            $v1
         );
         $this->assertEquals(
             (string) $sorted[5],
+            $v4
+        );
+        $this->assertEquals(
+            (string) $sorted[6],
             $v5
         );
     }

--- a/src/Naneau/SemVer/Parser.php
+++ b/src/Naneau/SemVer/Parser.php
@@ -67,6 +67,7 @@ class Parser
         }
 
         // Return
+        $version->setOriginalVersion($string);
         return $version;
     }
 }

--- a/src/Naneau/SemVer/Version.php
+++ b/src/Naneau/SemVer/Version.php
@@ -45,6 +45,11 @@ class Version extends Versionable
      */
     private $originalVersionString;
 
+    /**
+     * Set the original version string for later usage
+     *
+     * @param $version
+     */
     public function setOriginalVersion($version)
     {
         $this->originalVersionString = $version;

--- a/src/Naneau/SemVer/Version.php
+++ b/src/Naneau/SemVer/Version.php
@@ -39,6 +39,18 @@ class Version extends Versionable
     private $build;
 
     /**
+     * Original version String
+     *
+     * @var originalVersionString
+     */
+    private $originalVersionString;
+
+    public function setOriginalVersion($version)
+    {
+        $this->originalVersionString = $version;
+    }
+
+    /**
      * Get the pre release version
      *
      * @return PreRelease
@@ -111,19 +123,6 @@ class Version extends Versionable
      **/
     public function __toString()
     {
-        // Start with versionable part
-        $string = parent::__toString();
-
-        // Add pre-release
-        if ($this->hasPreRelease()) {
-            $string .= '-' . $this->getPreRelease();
-        }
-
-        // Add build
-        if ($this->hasBuild()) {
-            $string .= '+' . $this->getBuild();
-        }
-
-        return $string;
+        return $this->originalVersionString;
     }
 }


### PR DESCRIPTION
it is all about https://github.com/naneau/semver/issues/12
#### What's this PR do?
it modifies the SortTest::testSortStrings() to also sort a version in question (0.0.1-alpha)
the test checks if it is the Smallest (prior to 0.0.1) and if it returns in it original state.

also it fixes this issue by storing the original version string in the version instance createt by the Parser and returns ist on __toString()

#### Where should the reviewer start?
this is a quite small pr, run the new test on the old code, on the new code and look up the diff

#### How should this be manually tested?
there is a example in the issue, test this with and without the PR


#### Any background context you want to provide?
0.0.1-alpha is a valid semver 2.0 version, this format is an example in §9 on semver.org

#### What are the relevant tickets?
https://github.com/naneau/semver/issues/12


#### Questions:
why do we call the parser to give us a version-object?
shouldn't we create a version-object which uses the parser to get it's information?