### PR TITLE
Feature: Version::next()

### DIFF
--- a/Tests/CleanCopyVersionTest.php
+++ b/Tests/CleanCopyVersionTest.php
@@ -1,0 +1,46 @@
+<?php
+/**
+ * CleanCopyVersionTest.php
+ *
+ * @category        Naneau
+ * @package         SemVer
+ */
+
+use Naneau\SemVer\Parser;
+
+use \PHPUnit_Framework_TestCase as TestCase;
+
+/**
+ * CleanCopyVersionTest
+ *
+ * Testing Version::cleanCopy()
+ *
+ * @category        Naneau
+ * @package         SemVer
+ */
+class CleanCopyVersionTest extends TestCase
+{
+    public function testIncludesStandardVersion()
+    {
+        $version = Parser::parse('1.2.3');
+        $this->assertEquals('1.2.3', (string) $version->cleanCopy());
+    }
+
+    public function testIncludePreRelease()
+    {
+        $version = Parser::parse('1.0.0-beta.1');
+        $this->assertEquals('1.0.0-beta.1', (string) $version->cleanCopy());
+    }
+
+    public function testDiscardsBuild()
+    {
+        $version = Parser::parse('1.0.0+build');
+        $this->assertEquals('1.0.0', (string) $version->cleanCopy());
+    }
+
+    public function testDiscardsOriginalString()
+    {
+        $version = Parser::parse('1.0.0');
+        $this->assertEquals('', $version->cleanCopy()->getOriginalVersion());
+    }
+}

--- a/Tests/VersionNextTest.php
+++ b/Tests/VersionNextTest.php
@@ -1,0 +1,95 @@
+<?php
+/**
+ * VersionNextTest.php
+ *
+ * @category        Naneau
+ * @package         SemVer
+ */
+
+use Naneau\SemVer\Parser;
+use Naneau\SemVer\Version;
+
+use \PHPUnit_Framework_TestCase as TestCase;
+
+/**
+ * VersionNextTest
+ *
+ * Testing retrieving the next Version from a Version
+ *
+ * @category        Naneau
+ * @package         SemVer
+ */
+class VersionNextTest extends TestCase
+{
+    public function testNextAcceptsNoArg()
+    {
+        $version = Parser::parse('1.0.0');
+        $this->assertEquals('1.0.1', $version->next());
+    }
+
+    public function testNextAcceptsEmpty()
+    {
+        $version = Parser::parse('1.0.0');
+        $this->assertEquals('1.0.1', $version->next(false));
+    }
+
+    public function testNextAcceptsString()
+    {
+        $version = Parser::parse('1.0.0');
+        $this->assertEquals('1.0.2', $version->next('1.0.2'));
+    }
+
+    public function testNextThrowsExceptionOnUnhandledInputType()
+    {
+        $this->setExpectedException("InvalidArgumentException");
+        $version = Parser::parse('1.0.0');
+        $version->next(new \stdclass);
+    }
+
+    public function testNextThrowsExceptionOnPreReleaseBaseVersionWhenVersionNotPreRelease()
+    {
+        $this->setExpectedException("InvalidArgumentException");
+        $version = Parser::parse('1.0.0');
+        $version->next('1.0.0-rc');
+    }
+
+    /**
+     * @dataProvider versionStringProvider
+     */
+    public function test($expected, $base_str, $current_str)
+    {
+        $base = Parser::parse($base_str);
+        $current = Parser::parse($current_str);
+
+        $this->assertEquals($expected, (string) $current->next($base));
+    }
+
+    public function versionStringProvider()
+    {
+        return array(
+            // Move to next significant release
+            array('2.0.0', '2.0.0', '1.0.0'),
+            array('1.2.0', '1.2.0', '1.1.0'),
+            array('1.0.0', '1.0.0', '1.0.0-beta'),
+            array('1.0.0-rc.0', '1.0.0-rc.0', '1.0.0-beta.0'),
+            array('1.0.0-beta.0', '1.0.0-beta.0', '1.0.0-alpha.0'),
+            array('2.0.0-alpha.0', '2.0.0-alpha.0', '1.9.0'),
+            array('2.1.0-alpha.0', '2.1.0-alpha.0', '2.0.0'),
+            array('2.1.1-alpha.0', '2.1.1-alpha.0', '2.1.0'),
+
+            // inc patch
+            array('1.0.1', '1.0.0', '1.0.0'),
+            array('1.0.2', '1.0.0', '1.0.1'),
+            array('1.0.2', '1.0.2', '1.0.1'),
+
+            // inc prerelase number
+            array('1.0.0-beta.1', '1.0.0-beta.0', '1.0.0-beta.0'),
+            array('1.0.0-beta.2', '1.0.0-beta.0', '1.0.0-beta.1'),
+            array('1.0.0-beta.6000', '1.0.0-beta.0', '1.0.0-beta.5999'),
+
+            // Ignore build string
+            array('1.0.1', '1.0.0', '1.0.0+123421'),
+            array('1.0.0-beta.1', '1.0.0-beta.0', '1.0.0-beta.0+123421'),
+        );
+    }
+}

--- a/src/Naneau/SemVer/Version.php
+++ b/src/Naneau/SemVer/Version.php
@@ -138,10 +138,23 @@ class Version extends Versionable
      *
      * @param  Version|string|null $base
      * @return Version
+     * @throws InvalidArgumentException
      */
     public function next($base = null)
     {
-        $base = $this->ensureBase($base);
+        //  Ensure that $base is a Version. Parse it if we must, use ourself if
+        //  it is empty.
+        if (empty($base)) {
+            $base = $this;
+        }
+        else {
+            if (is_string($base)) {
+                $base = Parser::parse($base);
+            }
+            elseif (! $base instanceof Version) {
+                throw new InvalidArgumentException("\$base must be of type Version");
+            }
+        }
 
         // If the base is ahead of this Version then the next version will be
         // the base.
@@ -200,30 +213,6 @@ class Version extends Versionable
         }
 
         return $version;
-    }
-
-    /**
-     * Ensure that $base is a Version. Parse it if we must, use ourself if it
-     * is empty.
-     *
-     * @param Verion|string|null $base
-     * @return Version
-     * @throws InvalidArgumentException
-     */
-    private function ensureBase($base)
-    {
-        if (empty($base)) {
-            return $this;
-        }
-
-        if (is_string($base)) {
-            $base = Parser::parse($base);
-        }
-        elseif (! $base instanceof Version) {
-            throw new InvalidArgumentException("\$base must be of type Version");
-        }
-
-        return $base;
     }
 
     /**

--- a/src/Naneau/SemVer/Version.php
+++ b/src/Naneau/SemVer/Version.php
@@ -181,22 +181,6 @@ class Version extends Versionable
         return $next;
     }
 
-    private function ensureBase($base)
-    {
-        if (empty($base)) {
-            return $this;
-        }
-
-        if (is_string($base)) {
-            $base = Parser::parse($base);
-        }
-        elseif (! $base instanceof Version) {
-            throw new InvalidArgumentException("\$base must be of type Version");
-        }
-
-        return $base;
-    }
-
     /**
      * Create a new Version that discards the entity information of build and
      * originalVersionString
@@ -216,6 +200,30 @@ class Version extends Versionable
         }
 
         return $version;
+    }
+
+    /**
+     * Ensure that $base is a Version. Parse it if we must, use ourself if it
+     * is empty.
+     *
+     * @param Verion|string|null $base
+     * @return Version
+     * @throws InvalidArgumentException
+     */
+    private function ensureBase($base)
+    {
+        if (empty($base)) {
+            return $this;
+        }
+
+        if (is_string($base)) {
+            $base = Parser::parse($base);
+        }
+        elseif (! $base instanceof Version) {
+            throw new InvalidArgumentException("\$base must be of type Version");
+        }
+
+        return $base;
     }
 
     /**

--- a/src/Naneau/SemVer/Version.php
+++ b/src/Naneau/SemVer/Version.php
@@ -132,6 +132,27 @@ class Version extends Versionable
     }
 
     /**
+     * Create a new Version that discards the entity information of build and
+     * originalVersionString
+     *
+     * @return Version
+     */
+    public function cleanCopy()
+    {
+        $version = new Version;
+
+        $version->setMajor($this->getMajor());
+        $version->setMinor($this->getMinor());
+        $version->setPatch($this->getPatch());
+
+        if ($this->hasPreRelease()) {
+            $version->preRelease = clone($this->getPreRelease());
+        }
+
+        return $version;
+    }
+
+    /**
      * String representation of this Version
      *
      * @return string

--- a/src/Naneau/SemVer/Version.php
+++ b/src/Naneau/SemVer/Version.php
@@ -139,10 +139,9 @@ class Version extends Versionable
      * @param  Version|string|null $base
      * @return Version
      */
-    public function next(/* $base */)
+    public function next($base = null)
     {
-        $args = func_get_args();
-        $base = $this->ensureBase((count($args)) ? $args[0] : null);
+        $base = $this->ensureBase($base);
 
         // If the base is ahead of this Version then the next version will be
         // the base.


### PR DESCRIPTION
Adds a method to Version to get the next logical Version. This was necessary for some automatic tagging we set up in Jenkins and I thought it may be useful to others.

Here are the rules:

For the simple case it merely increments the least significant number (either the patch or pre-release number). To move between significant releases (E.g. 1.0 -> 1.1 or 1.0.0-alpha.5 -> 1.0.0-beta.0) a base version can be given. If the current version is less than the base version then the base will be the next version. If they are equal then the least significant number is incremented. If the current version is ahead of the base the least significant version is incremented from the current version, though if the base is in a pre-release state and the current is not then the version has not been updated with consistency and is considered an error.
